### PR TITLE
Go stack updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
-.odo/env
-.odo/odo-file-index.json
+.odo/
 main
 main.exe

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,25 @@
-.odo/
+# If you prefer the allow list template instead of the deny list, see community template:
+# https://github.com/github/gitignore/blob/main/community/Golang/Go.AllowList.gitignore
+#
+# Binaries for programs and plugins
+*.exe
+*.exe~
+*.dll
+*.so
+*.dylib
 main
-main.exe
+
+# Test binary, built with `go test -c`
+*.test
+
+# Output of the go coverage tool, specifically when used with LiteIDE
+*.out
+
+# Dependency directories (remove the comment below to include it)
+# vendor/
+
+# Go workspace file
+go.work
+
+# odo directory
+.odo/

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/devfile-samples/devfile-stack-go
 
-go 1.16
+go 1.19

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/devfile-samples/devfile-stack-go
 
-go 1.19
+go 1.24


### PR DESCRIPTION
# Update `.gitignore`

Merges `.gitignore` with content from GitHub's Go `.gitignore`.

# Update Go version

Bumps Go version to a more recent release.