### PR TITLE
Revert "Go stack updates"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,25 +1,4 @@
-# If you prefer the allow list template instead of the deny list, see community template:
-# https://github.com/github/gitignore/blob/main/community/Golang/Go.AllowList.gitignore
-#
-# Binaries for programs and plugins
-*.exe
-*.exe~
-*.dll
-*.so
-*.dylib
+.odo/env
+.odo/odo-file-index.json
 main
-
-# Test binary, built with `go test -c`
-*.test
-
-# Output of the go coverage tool, specifically when used with LiteIDE
-*.out
-
-# Dependency directories (remove the comment below to include it)
-# vendor/
-
-# Go workspace file
-go.work
-
-# odo directory
-.odo/
+main.exe

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/devfile-samples/devfile-stack-go
 
-go 1.24
+go 1.16


### PR DESCRIPTION
# Description

Reverts devfile-samples/devfile-stack-go#2 due to non terminating issue discovered in running integration testing on the devfile registry.

```
go: go.mod requires go >= 1.24 (running go 1.21.9; GOTOOLCHAIN=local)
```

Will need to first merge https://github.com/devfile/registry/pull/622 & https://github.com/devfile/registry/pull/621 and pin the starter project references before these changes can be merged.